### PR TITLE
daemon_hint always returns invisible server id

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -110,6 +110,7 @@ daemon_hint = function(server) {
   servrEnv$daemon_list = c(servrEnv$daemon_list, server)
   message('To stop the server, run servr::daemon_stop("', server, '")',
           ' or restart your R session')
+  invisible(server)
 }
 
 #' Utilities for daemonized servers


### PR DESCRIPTION
This would make it easier for me to write some tests around servr. For example:

```s
res <- servr::httd(port=4988, daemon=TRUE)
# render some stuff in the browser and grab DOM elements with RSelenium
# test whether DOM elements are as intended
# once all tests are run, stop the server
servr::daemon_stop(res)
```