### PR TITLE
allow watch_dir to watch specific file patterns and execute a build

### DIFF
--- a/R/static.R
+++ b/R/static.R
@@ -30,21 +30,26 @@ httd = function(dir = '.', ...) {
 
 #' @rdname httd
 #' @export
-httw = function(dir = '.', ...) {
-  dynamic_site(dir, ..., build = watch_dir('.'))
+httw = function(dir = '.', pattern = NULL, build = NULL, ...) {
+  dynamic_site(dir, ..., build = watch_dir('.', pattern = pattern, build = build))
 }
 
-watch_dir = function(dir = '.') {
+watch_dir = function(dir = '.', pattern = NULL, build = NULL) {
   mtime = function(dir) {
     file.info(
-      list.files(dir, all.files = TRUE, full.names = TRUE, no.. = TRUE)
+      list.files(dir, pattern = pattern, all.files = TRUE,
+         full.names = TRUE, no.. = TRUE
+      )
     )[, 'mtime', drop = FALSE]
   }
   info = mtime(dir)
   function(...) {
     info2 = mtime(dir)
     changed = !identical(info, info2)
-    if (changed) info <<- info2
+    if (changed) {
+      if (!is.null(build)) build(...)
+      info <<- info2
+    }
     changed
   }
 }

--- a/man/httd.Rd
+++ b/man/httd.Rd
@@ -6,7 +6,7 @@
 \usage{
 httd(dir = ".", ...)
 
-httw(dir = ".", ...)
+httw(dir = ".", pattern = NULL, build = NULL, ...)
 }
 \arguments{
 \item{dir}{the root directory to serve}


### PR DESCRIPTION
This PR adds more flexibility to the `watch_dir` and `httw` functions by adding two arguments:

1. `pattern` of files to watch, passed to `list.files`.
2. `build` a build function that gets executed when any of the watched files change.





