### PR TITLE
Make httd and httw return the deamon id

### DIFF
--- a/R/dynamic.R
+++ b/R/dynamic.R
@@ -221,7 +221,8 @@ dynamic_site = function(
       })
     }
   )
-  res$start_server(app)
+  id = res$start_server(app)
+  invisible(id)
 }
 
 #' Determine if R Markdown files need to be re-built

--- a/R/static.R
+++ b/R/static.R
@@ -23,7 +23,8 @@ httd = function(dir = '.', ...) {
   }
   res = server_config(dir, ...)
   app = list(call = serve_dir(dir))
-  res$start_server(app)
+  id = res$start_server(app)
+  invisible(id)
 }
 
 #' @param watch a directory under which \code{httw()} is to watch for changes;
@@ -39,9 +40,10 @@ httd = function(dir = '.', ...) {
 httw = function(
   dir = '.', watch = '.', pattern = NULL, all_files = FALSE, handler = NULL, ...
 ) {
-  dynamic_site(dir, ..., build = watch_dir(
+  id = dynamic_site(dir, ..., build = watch_dir(
     watch, pattern = pattern, all_files = all_files, handler = handler
   ))
+  invisible(id)
 }
 
 watch_dir = function(dir = '.', pattern = NULL, all_files = FALSE, handler = NULL) {


### PR DESCRIPTION
Here's the context: I want to be able to programmatically launch and stop a servr.daemon from a shiny app, and for now I'm doing this weird thing to catch the daemon id and close it with a button: (reprex here, of course)

```
library(shiny)

ui <- fluidPage(
  actionButton("go", "Launch daemon"),
  actionButton("stop", "Stop daemon"), 
  textOutput("srv")
)

server <- function(input, output, session) {
  r <- reactiveValues()
  r$srv <- servr::daemon_list()
  
  output$srv <- renderText({
    r$srv
    })

  observeEvent(input$go, {
    res <- capture.output(
      servr::httw(tempdir(), daemon = TRUE),
      type = 'message'
    )
    r$last_daemon <-  gsub('.* servr::daemon_stop\\("(.*)"\\) .*', "\\1", res[1])
    r$srv <- servr::daemon_list()
  })
  
  observeEvent(input$stop, {
    servr::daemon_stop(r$last_daemon)
    r$srv <- servr::daemon_list()
  })
}

shinyApp(ui, server)
```

So my PR consists of just returning the id of the daemon, so that I can programmatically do : 

```
# remotes::install_github("ColinFay/servr")
res <- servr::httw(tempdir(), daemon = TRUE)
servr::daemon_stop(res)
```

Which would be cleaner I guess: 

```
library(shiny)

ui <- fluidPage(
  actionButton("go", "Launch daemon"),
  actionButton("stop", "Stop daemon"), 
  textOutput("srv")
)

server <- function(input, output, session) {
  r <- reactiveValues()
  r$srv <- servr::daemon_list()
  
  output$srv <- renderText({ r$srv })

  observeEvent(input$go, {
    
    res <- servr::httw(tempdir(), daemon = TRUE)
    
    r$last_daemon <-  res
    r$srv <- servr::daemon_list()
  })
  
  observeEvent(input$stop, {
    servr::daemon_stop(r$last_daemon)
    r$srv <- servr::daemon_list()
  })
}

shinyApp(ui, server)
```