### PR TITLE
support for open-ended range requests

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,7 +2,7 @@
 
 BUG FIXES
 
-- Refinements to HTTP range request responses. Open-ended range requests (including "Range: bytes=0-") should now be correctly handled.
+- Refinements to HTTP range request responses. Open-ended range requests (including "Range: bytes=0-") should now be correctly handled (thanks, @raymondben, #41).
 
 		 CHANGES IN servr VERSION 0.15
 

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,8 @@
 		 CHANGES IN servr VERSION 0.16
 
+BUG FIXES
 
+- Refinements to HTTP range request responses. Open-ended range requests (including "Range: bytes=0-") should now be correctly handled.
 
 		 CHANGES IN servr VERSION 0.15
 
@@ -66,7 +68,7 @@ BUG FIXES
 
 NEW FEATURES
 
-- added another implementation of the daemoinzed server based on the later package, since the previous implmentation based on `httpuv::startDaemonizedServer()` could crash the R session on Windows
+- added another implementation of the daemonized server based on the later package, since the previous implmentation based on `httpuv::startDaemonizedServer()` could crash the R session on Windows
 
 		 CHANGES IN servr VERSION 0.7
 

--- a/R/static.R
+++ b/R/static.R
@@ -203,23 +203,31 @@ serve_dir = function(dir = '.') function(req) {
         body = paste2('Not found:', path)
       ))
 
-    type = guess_type(path)
-    range = req$HTTP_RANGE
+      type = guess_type(path)
+      range = req$HTTP_RANGE
 
-    # Chrome sends the range reuest 'bytes=0-' and I'm not sure what to do:
-    # http://stackoverflow.com/a/18745164/559676
-    if (is.null(range) || identical(range, 'bytes=0-')) read_raw(path) else {
-      range = strsplit(range, split = "(=|-)")[[1]]
-      b2 = as.numeric(range[2])
-      b3 = as.numeric(range[3])
+      if (is.null(range)) {
+          read_raw(path)
+      } else {
+          range = strsplit(range, split = "(=|-)")[[1]]
+          b2 = as.numeric(range[2])
+          if (length(range) == 2 && range[1] == "bytes") {
+              # open-ended range request
+              # e.g. Chrome sends the range reuest 'bytes=0-'
+              # http://stackoverflow.com/a/18745164/559676
+              range[3] <- file_size(path)-1
+          }
+          b3 <- as.numeric(range[3])
+          if (length(range) < 3 || (range[1] != "bytes") || (b2 >= b3))
+              return(list(
+                  status = 416L, headers = list('Content-Type' = 'text/plain'),
+                  body = 'Requested range not satisfiable\r\n'
+              ))
 
-      if (length(range) < 3 || (range[1] != "bytes") || (b2 >= b3) || (b3 == 0))
-        return(list(
-          status = 416L, headers = list('Content-Type' = 'text/plain'),
-          body = 'Requested range not satisfiable\r\n'
-        ))
-
-      status = 206L  # partial content
+          status = 206L  # partial content
+          # type may also need to be changed
+          # e.g. to "multipart/byteranges" if multipart range support is added at a later date
+          # or possibly to "application/octet-stream" for binary files
 
       con = file(path, open = "rb", raw = TRUE)
       on.exit(close(con))
@@ -231,7 +239,8 @@ serve_dir = function(dir = '.') function(req) {
   list(
     status = status, body = body,
     headers = c(list('Content-Type' = type), if (status == 206L) list(
-      'Content-Range' = paste(sub('=', ' ', req$HTTP_RANGE), file_size(path), sep = '/')
-    ))
+      'Content-Range' = paste0("bytes ", range[2], "-", range[3], "/", file_size(path))
+      ),
+      'Accept-Ranges: bytes') # indicates that the server supports range requests
   )
 }

--- a/R/static.R
+++ b/R/static.R
@@ -203,31 +203,31 @@ serve_dir = function(dir = '.') function(req) {
         body = paste2('Not found:', path)
       ))
 
-      type = guess_type(path)
-      range = req$HTTP_RANGE
+    type = guess_type(path)
+    range = req$HTTP_RANGE
 
-      if (is.null(range)) {
-          read_raw(path)
-      } else {
-          range = strsplit(range, split = "(=|-)")[[1]]
-          b2 = as.numeric(range[2])
-          if (length(range) == 2 && range[1] == "bytes") {
-              # open-ended range request
-              # e.g. Chrome sends the range reuest 'bytes=0-'
-              # http://stackoverflow.com/a/18745164/559676
-              range[3] <- file_size(path)-1
-          }
-          b3 <- as.numeric(range[3])
-          if (length(range) < 3 || (range[1] != "bytes") || (b2 >= b3))
-              return(list(
-                  status = 416L, headers = list('Content-Type' = 'text/plain'),
-                  body = 'Requested range not satisfiable\r\n'
-              ))
+    if (is.null(range)) {
+      read_raw(path)
+    } else {
+      range = strsplit(range, split = "(=|-)")[[1]]
+      b2 = as.numeric(range[2])
+      if (length(range) == 2 && range[1] == "bytes") {
+        # open-ended range request
+        # e.g. Chrome sends the range reuest 'bytes=0-'
+        # http://stackoverflow.com/a/18745164/559676
+        range[3] = file_size(path) - 1
+      }
+      b3 = as.numeric(range[3])
+      if (length(range) < 3 || (range[1] != "bytes") || (b2 >= b3))
+        return(list(
+          status = 416L, headers = list('Content-Type' = 'text/plain'),
+          body = 'Requested range not satisfiable\r\n'
+        ))
 
-          status = 206L  # partial content
-          # type may also need to be changed
-          # e.g. to "multipart/byteranges" if multipart range support is added at a later date
-          # or possibly to "application/octet-stream" for binary files
+      status = 206L  # partial content
+      # type may also need to be changed
+      # e.g. to "multipart/byteranges" if multipart range support is added at a later date
+      # or possibly to "application/octet-stream" for binary files
 
       con = file(path, open = "rb", raw = TRUE)
       on.exit(close(con))


### PR DESCRIPTION
Support for open-ended range requests like "bytes=0-". These requests are valid according to RFC7233, it just means to deliver the remainder of the content from the specified start byte onwards. So 'bytes=0-' is effectively asking for the whole file.

Re: https://github.com/yihui/servr/blob/master/R/static.R#L209 where you say "Chrome sends the range request 'bytes=0-'". I think the behaviour of browsers to send an initial 'bytes=0-' request is to figure out if the server supports range requests. If it does not, then they get the whole file back (with response status 200). If it does, they get a 206 response and an 'Accept-Ranges: bytes' header, and the file delivery begins. The client browser then knows that range requests are possible, and it can abort that download if appropriate and request other byte ranges as required.

Changes here:

- requests for 'bytes=0-' will be returned with a status 206 header, not status 200
- all partial content responses include an 'Accept-Ranges: bytes' header to indicate that the server supports range requests
- 'Content-Range' response header is now correct for open-ended range requests

Remaining issue: static file delivery current works by reading the whole file into memory first. Probably better to stream direct from disk, e.g. https://github.com/yihui/servr/issues/35. Note though that httpuv's static file serving does not currently support range requests.