### PR TITLE
Fix the malformed Accept-Ranges header.

### DIFF
--- a/R/static.R
+++ b/R/static.R
@@ -241,6 +241,6 @@ serve_dir = function(dir = '.') function(req) {
     headers = c(list('Content-Type' = type), if (status == 206L) list(
       'Content-Range' = paste0("bytes ", range[2], "-", range[3], "/", file_size(path))
       ),
-      'Accept-Ranges: bytes') # indicates that the server supports range requests
+      'Accept-Ranges' = 'bytes') # indicates that the server supports range requests
   )
 }


### PR DESCRIPTION
Fixes #46 

Here's what the headers look like after the change. The malformed `Accept-Ranges` header is fixed.

![image](https://user-images.githubusercontent.com/157782/87677143-676ca400-c747-11ea-9648-00ca47d49c11.png)
