### PR TITLE
Allow for Perl-like regex in `httw()`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,8 @@
 		 CHANGES IN servr VERSION 0.21
 
+MINOR CHANGES
+
+- `httw()` now accepts Perl-like regular expression for the `pattern` parameter
 
 
 		 CHANGES IN servr VERSION 0.20

--- a/R/static.R
+++ b/R/static.R
@@ -30,7 +30,7 @@ httd = function(dir = '.', ...) {
 #' @param watch a directory under which \code{httw()} is to watch for changes;
 #'   if it is a relative path, it is relative to the \code{dir} argument
 #' @param pattern a regular expression to
-#'   determine the files to watch. Supports Perl-like regular expressions unlike \code{list.files()}
+#'   determine the files to watch. Supports Perl-like regular expression
 #' @param all_files whether to watch all files including the hidden files
 #' @param handler a function to be called every time any files are changed or
 #'   added under the directory; its argument is a character vector of the
@@ -51,14 +51,14 @@ watch_dir = function(dir = '.', pattern = NULL, all_files = FALSE, handler = NUL
     owd = setwd(cwd); on.exit(setwd(owd), add = TRUE)
     info = file.info(
       grep(pattern,
-               list.files(
-                  dir,
-                  all.files = all_files, full.names = TRUE, recursive = TRUE,
-                   no.. = TRUE
-               )
-               perl = TRUE,
-               value = TRUE
-          ))[, 'mtime', drop = FALSE]
+           list.files(
+             dir,
+             all.files = all_files, full.names = TRUE, recursive = TRUE,
+             no.. = TRUE
+           ),
+           perl = TRUE,
+           value = TRUE
+      ))[, 'mtime', drop = FALSE]
     rownames(info) = gsub('^[.]/', '', rownames(info))
     info
   }
@@ -247,7 +247,7 @@ serve_dir = function(dir = '.') function(req) {
     status = status, body = body,
     headers = c(list('Content-Type' = type), if (status == 206L) list(
       'Content-Range' = paste0("bytes ", range[2], "-", range[3], "/", file_size(path))
-      ),
-      'Accept-Ranges' = 'bytes') # indicates that the server supports range requests
+    ),
+    'Accept-Ranges' = 'bytes') # indicates that the server supports range requests
   )
 }

--- a/R/static.R
+++ b/R/static.R
@@ -49,16 +49,19 @@ watch_dir = function(dir = '.', pattern = NULL, all_files = FALSE, handler = NUL
   cwd = getwd()
   mtime = function(dir) {
     owd = setwd(cwd); on.exit(setwd(owd), add = TRUE)
-    info = file.info(
-      grep(pattern,
-           list.files(
-             dir,
-             all.files = all_files, full.names = TRUE, recursive = TRUE,
-             no.. = TRUE
-           ),
-           perl = TRUE,
-           value = TRUE
-      ))[, 'mtime', drop = FALSE]
+    files <- list.files(
+      dir,
+      all.files = all_files, full.names = TRUE, recursive = TRUE,
+      no.. = TRUE
+    )
+    if (!is.null(pattern)){
+      files <- grep(pattern,
+                    files,
+                    perl = TRUE,
+                    value = TRUE
+      )
+    }
+    info = file.info(files)[, 'mtime', drop = FALSE]
     rownames(info) = gsub('^[.]/', '', rownames(info))
     info
   }

--- a/R/static.R
+++ b/R/static.R
@@ -29,8 +29,8 @@ httd = function(dir = '.', ...) {
 
 #' @param watch a directory under which \code{httw()} is to watch for changes;
 #'   if it is a relative path, it is relative to the \code{dir} argument
-#' @param pattern a regular expression passed to \code{\link{list.files}()} to
-#'   determine the files to watch
+#' @param pattern a regular expression to
+#'   determine the files to watch. Supports Perl-like regular expressions unlike \code{list.files()}
 #' @param all_files whether to watch all files including the hidden files
 #' @param handler a function to be called every time any files are changed or
 #'   added under the directory; its argument is a character vector of the
@@ -49,10 +49,16 @@ watch_dir = function(dir = '.', pattern = NULL, all_files = FALSE, handler = NUL
   cwd = getwd()
   mtime = function(dir) {
     owd = setwd(cwd); on.exit(setwd(owd), add = TRUE)
-    info = file.info(list.files(
-      dir, pattern, all.files = all_files, full.names = TRUE, recursive = TRUE,
-      no.. = TRUE
-    ))[, 'mtime', drop = FALSE]
+    info = file.info(
+      grep(pattern,
+               list.files(
+                  dir,
+                  all.files = all_files, full.names = TRUE, recursive = TRUE,
+                   no.. = TRUE
+               )
+               perl = TRUE,
+               value = TRUE
+          ))[, 'mtime', drop = FALSE]
     rownames(info) = gsub('^[.]/', '', rownames(info))
     info
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -115,7 +115,7 @@ daemon_list = function() {
 # watch files with pattern, and rebuild them if necessary
 build_watcher = function(pattern, build, dir = getwd()) {
   source_info = function() {
-    file.info(list.files(dir, pattern, recursive = TRUE))[, 'mtime', drop = FALSE]
+    file.info(grep(pattern, list.files(dir, recursive = TRUE), perl = TRUE, value = TRUE))[, 'mtime', drop = FALSE]
   }
   info = source_info()
   function(message) {

--- a/man/dynamic_site.Rd
+++ b/man/dynamic_site.Rd
@@ -111,8 +111,8 @@ if (interactive()) servr::rmdv1()  # serve the current dir with R Markdown v1
 if (interactive()) servr::rmdv2()  # or R Markdown v2
 
 # built-in examples
-servr::serve_example("rmd", servr::rmdv1)
-servr::serve_example("rmd", servr::rmdv2)
+servr::serve_example('rmd', servr::rmdv1)
+servr::serve_example('rmd', servr::rmdv2)
 }
 \references{
 R Markdown v1: \url{https://cran.r-project.org/package=markdown}. R

--- a/man/httd.Rd
+++ b/man/httd.Rd
@@ -24,8 +24,8 @@ httw(
 \item{watch}{a directory under which \code{httw()} is to watch for changes;
 if it is a relative path, it is relative to the \code{dir} argument}
 
-\item{pattern}{a regular expression passed to \code{\link{list.files}()} to
-determine the files to watch}
+\item{pattern}{a regular expression to
+determine the files to watch. Supports Perl-like regular expression}
 
 \item{all_files}{whether to watch all files including the hidden files}
 

--- a/man/make.Rd
+++ b/man/make.Rd
@@ -28,8 +28,8 @@ You must have installed GNU Make to use this function. This is normally
   contains GNU Make.
 }
 \examples{
-# some built-in examples (if you are not familiar with make, you can take a look
-# at the Makefile of each example)
-servr::serve_example("make1", servr::make)
-servr::serve_example("make2", servr::make)
+# some built-in examples (if you are not familiar with make,
+# you can take a look at the Makefile of each example)
+servr::serve_example('make1', servr::make)
+servr::serve_example('make2', servr::make)
 }

--- a/man/serve_example.Rd
+++ b/man/serve_example.Rd
@@ -28,10 +28,10 @@ Use server functions to serve built-in examples of this package.
 }
 \examples{
 # R Markdown v1 or v2
-servr::serve_example("rmd", servr::rmdv1)
-servr::serve_example("rmd", servr::rmdv2)
+servr::serve_example('rmd', servr::rmdv1)
+servr::serve_example('rmd', servr::rmdv2)
 
 # GNU Make
-servr::serve_example("make1", servr::make)
-servr::serve_example("make2", servr::make)
+servr::serve_example('make1', servr::make)
+servr::serve_example('make2', servr::make)
 }


### PR DESCRIPTION
This adds support for Perl-like regex for the `pattern` parameter of the `httw()` function.

Instead of passing the `pattern` argument to `list.files()`, which only supports extended regular expression and therefore can't utilise negative lookaround to exclude patterns, we essentially list all files and then pattern match using  `grep` and `perl=TRUE`.

This makes exclusion of certain patterns (files named "PACKAGE", for example) possible.