### PR TITLE
animint deprecated for animint2

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ http.server`. It may be used to serve:
 - [**googleVis**](https://cran.r-project.org/package=googleVis) charts (to avoid
   the Flash security issue)
 - D3 charts which need to load JSON from local files (see also the
-  [**animint**](https://github.com/tdhock/animint) package), and
+  [**animint2**](https://github.com/tdhock/animint2) package), and
   [**samatha**](https://github.com/DASpringate/samatha), etc
 
 You can either run `servr::httd()` in an interactive R session, or run from


### PR DESCRIPTION
Hi, 

just changed animint to animint2 (with corresponding URL) 

Best.